### PR TITLE
fix: typo from 'Remeber' to 'Remember'

### DIFF
--- a/tutorial.json
+++ b/tutorial.json
@@ -929,7 +929,7 @@
               "76e9a739cc8f3646b273de3ebf5b332345c1c8bb"
             ]
           },
-          "content": "You will be making a website boilerplate. You can make a new folder with `mkdir <folder_name>`. `mkdir` stands for \"make directory\". Make a `website` directory in this `project` folder. Remeber that \"directory\" and \"folder\" mean the same thing.",
+          "content": "You will be making a website boilerplate. You can make a new folder with `mkdir <folder_name>`. `mkdir` stands for \"make directory\". Make a `website` directory in this `project` folder. Remember that \"directory\" and \"folder\" mean the same thing.",
           "hints": [
             "Enter `mkdir website` into the terminal",
             "Make sure to make it in the `project` folder",


### PR DESCRIPTION
Fix typo from 'Remeber' -> 'Remember'

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
